### PR TITLE
Honor PHP temp directory config

### DIFF
--- a/tests/ManifestSerializerTest.php
+++ b/tests/ManifestSerializerTest.php
@@ -79,7 +79,7 @@ class ManifestSerializerTest extends \PHPUnit\Framework\TestCase {
      */
     public function testCanSerializeToFile(): void {
         $src        = __DIR__ . '/_fixture/library.xml';
-        $dest       = '/tmp/' . \uniqid('serializer', true);
+        $dest       = \sys_get_temp_dir() . '/' . \uniqid('serializer', true);
         $manifest   = ManifestLoader::fromFile($src);
         $serializer = new ManifestSerializer();
         $serializer->serializeToFile($manifest, $dest);


### PR DESCRIPTION
Fixed `/tmp` directory can be outside `open_basedir` scope. This fixes it using PHP config which is expected to be correct (and `sys_get_temp_dir` will return `/tmp` by default if no config is set).