### PR TITLE
Removed deprecated --no-suggest

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -21,7 +21,6 @@
             <arg value="--no-interaction"/>
             <arg value="--no-progress"/>
             <arg value="--no-ansi"/>
-            <arg value="--no-suggest"/>
             <arg value="--optimize-autoloader"/>
         </exec>
     </target>


### PR DESCRIPTION
Composer 2.0 is due to be released very shortly. This option has been deleted with no replacement.