### PR TITLE
Add .gitattributes with export-ignore rules to exclude test/build files from dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+/examples        export-ignore
+/tests           export-ignore
+/.gitattributes  export-ignore
+/.gitignore      export-ignore
+/.php_cs.dist    export-ignore
+/.travis.yml     export-ignore
+/build.xml       export-ignore
+/phive.xml       export-ignore
+/phpunit.xml     export-ignore
+/psalm.xml       export-ignore


### PR DESCRIPTION
Similar to theseer/tokenizer#9, adding a `.gitattributes` file with `export-ignore` rules can greatly reduce the zip file size as it excludes tests, examples, and other build/test related files. 

Thank you.