### PR TITLE
Fix PHP 8.1 deprecation notices

### DIFF
--- a/src/xml/ElementCollection.php
+++ b/src/xml/ElementCollection.php
@@ -24,17 +24,17 @@ abstract class ElementCollection implements \Iterator {
         $this->importNodes($nodeList);
     }
 
-    abstract public function current();
+    abstract public function current(): ManifestElement;
 
     public function next(): void {
         $this->position++;
     }
 
-    public function key() {
+    public function key(): int {
         return $this->position;
     }
 
-    public function valid() {
+    public function valid(): bool {
         return $this->position < \count($this->nodes);
     }
 

--- a/tests/xml/ElementCollectionTest.php
+++ b/tests/xml/ElementCollectionTest.php
@@ -12,7 +12,7 @@ class ElementCollectionTest extends TestCase {
         $this->expectException(ElementCollectionException::class);
 
         new class($dom->documentElement->childNodes) extends ElementCollection {
-            public function current() {}
+            public function current(): ManifestElement {}
         };
     }
 }


### PR DESCRIPTION
From https://github.com/sebastianbergmann/phpunit/runs/3112779264:

```
Deprecated: Return type of PharIo\Manifest\ElementCollection::current() should either be compatible with
Iterator::current(): mixed, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress
the notice in /home/runner/work/phpunit/phpunit/vendor/phar-io/manifest/src/xml/ElementCollection.php on line 27

Deprecated: Return type of PharIo\Manifest\ElementCollection::key() should either be compatible with
Iterator::key(): mixed, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress
the notice in /home/runner/work/phpunit/phpunit/vendor/phar-io/manifest/src/xml/ElementCollection.php on line 33

Deprecated: Return type of PharIo\Manifest\ElementCollection::valid() should either be compatible with
Iterator::valid(): bool, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress
the notice in /home/runner/work/phpunit/phpunit/vendor/phar-io/manifest/src/xml/ElementCollection.php on line 37
```
