### PR TITLE
Fix: Use `codecov/codecov-action` to report coverage to `codecov.io`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,9 @@ jobs:
         run: "composer install --no-interaction --optimize-autoloader --prefer-dist"
 
       - name: "Run PHPUnit"
-        run: "phpunit"
+        run: "phpunit --coverage-clover build/logs/clover.xml"
 
-      - name: "Send code coverage report to Codecov.io"
-        run: "bash <(curl -s https://codecov.io/bash)"
+      - name: "Send code coverage report to codecov.io"
+        uses: "codecov/codecov-action@v2"
+        with:
+          files: "build/logs/clover.xml"


### PR DESCRIPTION
This pull request

- [x] uses [`codecov/codecov-action`](https://github.com/codecov/codecov-action) to report coverage to `codecov.io`