### PR TITLE
Fix: Consistently use `basedir` property

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -56,7 +56,7 @@
     </target>
 
     <target name="php-cs-fixer" depends="install-tools" description="Dry run php csfixer">
-        <exec executable="./tools/php-cs-fixer" failonerror="true">
+        <exec executable="${basedir}/tools/php-cs-fixer" failonerror="true">
             <arg value="fix" />
             <arg value="--dry-run" />
         </exec>


### PR DESCRIPTION
This pull request

- [x] consistently uses the `basedir` property in `build.xml`