### PR TITLE
Fix: Use `phpunit/phpunit` as installed with `phive`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,13 +69,18 @@ jobs:
           extensions: "${{ env.extensions }}"
           ini-values: "display_errors=On, error_reporting=-1, memory_limit=2G"
           php-version: "${{ matrix.php-versions }}"
-          tools: "phpunit:8.5"
+          tools: "phive"
 
       - name: "Install dependencies with composer"
         run: "composer install --no-interaction --optimize-autoloader --prefer-dist"
 
+      - name: "Install dependencies with phive"
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: "ant install-tools"
+
       - name: "Run PHPUnit"
-        run: "phpunit --coverage-clover build/logs/clover.xml"
+        run: "tools/phpunit --coverage-clover build/logs/clover.xml"
 
       - name: "Send code coverage report to codecov.io"
         uses: "codecov/codecov-action@v2"


### PR DESCRIPTION
This pull request

- [x] uses `phpunit/phpunit` as installed with `phive` when running tests on GitHub Actions