### PR TITLE
Fix: Do not fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
     runs-on: "${{ matrix.operating-system }}"
 
     strategy:
+      fail-fast: false
+
       matrix:
         operating-system:
           - "macos-latest"


### PR DESCRIPTION
This pull request

- [x] runs all jobs in the matrix even when one of them failed

💁‍♂️ For reference, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast.