### PR TITLE
Fix: Run jobs on `ubuntu-latest` only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,15 +40,10 @@ jobs:
   tests:
     name: "Tests"
 
-    runs-on: "${{ matrix.operating-system }}"
+    runs-on: "ubuntu-latest"
 
     strategy:
       matrix:
-        operating-system:
-          - "macos-latest"
-          - "ubuntu-latest"
-          - "windows-latest"
-
         php-versions:
           - "7.3"
           - "7.4"


### PR DESCRIPTION
This pull request

- [x] runs jobs on `ubuntu-latest` only