### PR TITLE
Do not use implicitly nullable parameters

### DIFF
--- a/src/values/Manifest.php
+++ b/src/values/Manifest.php
@@ -76,7 +76,7 @@ class Manifest {
         return $this->type->isExtension();
     }
 
-    public function isExtensionFor(ApplicationName $application, Version $version = null): bool {
+    public function isExtensionFor(ApplicationName $application, ?Version $version = null): bool {
         if (!$this->isExtension()) {
             return false;
         }


### PR DESCRIPTION
This pull request only contains the necessary code change for https://github.com/sebastianbergmann/phpunit/issues/5719, it does not update the ChangeLog or prepare a release in any other way. This is because I ran into the following problems.

The [ChangeLog](https://github.com/phar-io/manifest/blob/master/CHANGELOG.md#210---15022022) that there is a `2.1.0` release. But there is no `2.1.0` tag, the latest tag is `2.0.3`.

Since the release of `2.0.3`, [support for PHP 7.2 was dropped](https://github.com/phar-io/manifest/commit/68f26956969c4f2cc18ea16b30b3cda58643ad49). For PHPUnit 8.5, we need a version of `phar-io/manifest` that supports PHP 7.2.